### PR TITLE
fix: add branchs to trigger ci pipeline

### DIFF
--- a/.github/workflows/linter-test.yml
+++ b/.github/workflows/linter-test.yml
@@ -2,6 +2,8 @@ name: Run Linter and Tests
 
 on: 
   push:
+    tags-ignore: 
+      - '*'
 
 jobs:
   linter:

--- a/.github/workflows/linter-test.yml
+++ b/.github/workflows/linter-test.yml
@@ -2,8 +2,6 @@ name: Run Linter and Tests
 
 on: 
   push:
-    branches: 
-      - '*'
 
 jobs:
   linter:

--- a/.github/workflows/linter-test.yml
+++ b/.github/workflows/linter-test.yml
@@ -2,8 +2,13 @@ name: Run Linter and Tests
 
 on: 
   push:
-    tags-ignore: 
-      - '*'
+    branches:
+      - 'main'
+      - 'feat/**'
+      - 'fix/**'
+      - 'ci/**'
+      - 'cd/**'
+      - 'chore/**'
 
 jobs:
   linter:


### PR DESCRIPTION
## Describe the Change

Add rules to only specified branchs trigger the CI pipeline

## Past and Current Behavior

Before, only branch main trigger the CI pipeline, but now, all specified branchs will trigger the CI pipeline

## Checklist

- [ ] - Feature 🚀 
- [x] - Fix 🧰
- [ ] - Documentation 📖 
- [x] - Improvement 🌟
- [ ] - Hot Fix 🔥
- [ ] - Security 🔒
- [ ] - Pass in All Tests 🧪
- [ ] - Create new warnings ⚠️
- [ ] - Create new comments 💬
